### PR TITLE
fix deprecation: add TreeBuilder as a native return type declaration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder() :TreeBuilder
     {
         $treeBuilder = new TreeBuilder('recaptcha');
 


### PR DESCRIPTION
This close#4 fixing deprecation: add TreeBuilder as a native return type declaration