### PR TITLE
Fix deprecation no return type declaration

### DIFF
--- a/src/DependencyInjection/RecaptchaExtension.php
+++ b/src/DependencyInjection/RecaptchaExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 class RecaptchaExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container) :void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');

--- a/src/Form/ReCaptchaType.php
+++ b/src/Form/ReCaptchaType.php
@@ -44,7 +44,7 @@ class ReCaptchaType extends AbstractType
     /**
      * @inheritDoc
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options) :void
     {
         $view->vars['type'] = $options['type'];
         $view->vars['google_site_key'] = $this->parameterBag->get('victor_prdh_recaptcha.google_site_key');
@@ -66,7 +66,7 @@ class ReCaptchaType extends AbstractType
     /**
      * @inheritDoc
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver) :void
     {
         $resolver
             ->setDefault('type', 'checkbox')

--- a/src/Validator/Constraints/IsValidCaptchaValidator.php
+++ b/src/Validator/Constraints/IsValidCaptchaValidator.php
@@ -37,7 +37,7 @@ class IsValidCaptchaValidator extends ConstraintValidator
         $this->translator = $translator;
     }
 
-    public function validate($value, Constraint $constraint) :RequestContext
+    public function validate($value, Constraint $constraint) :void
     {
         $request = $this->requestStack->getMainRequest();
         $result = $this->reCaptcha

--- a/src/Validator/Constraints/IsValidCaptchaValidator.php
+++ b/src/Validator/Constraints/IsValidCaptchaValidator.php
@@ -45,7 +45,7 @@ class IsValidCaptchaValidator extends ConstraintValidator
             ->verify($request->request->get('g-recaptcha-response'), $request->getClientIp());
 
             if(in_array('missing-input-response', $result->getErrorCodes())) {
-                return $this->context->addViolation($this->translator->trans('verify.captcha', array(), 'victorprdh_recaptcha'));
+                $this->context->addViolation($this->translator->trans('verify.captcha', array(), 'victorprdh_recaptcha'));
             }
 
             if(in_array('timeout-or-duplicate', $result->getErrorCodes())) {
@@ -69,7 +69,7 @@ class IsValidCaptchaValidator extends ConstraintValidator
             }
 
             if (!$result->isSuccess()) {
-                return $this->context->addViolation($this->translator->trans('invalid.captcha', array(), 'victorprdh_recaptcha'));
+                $this->context->addViolation($this->translator->trans('invalid.captcha', array(), 'victorprdh_recaptcha'));
             }
     }
 }

--- a/src/Validator/Constraints/IsValidCaptchaValidator.php
+++ b/src/Validator/Constraints/IsValidCaptchaValidator.php
@@ -37,7 +37,7 @@ class IsValidCaptchaValidator extends ConstraintValidator
         $this->translator = $translator;
     }
 
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint) :RequestContext
     {
         $request = $this->requestStack->getMainRequest();
         $result = $this->reCaptcha
@@ -69,7 +69,7 @@ class IsValidCaptchaValidator extends ConstraintValidator
             }
 
             if (!$result->isSuccess()) {
-                $this->context->addViolation($this->translator->trans('invalid.captcha', array(), 'victorprdh_recaptcha'));
+                return $this->context->addViolation($this->translator->trans('invalid.captcha', array(), 'victorprdh_recaptcha'));
             }
     }
 }


### PR DESCRIPTION
I find a solution to fix deprecation on the method validate from IsValidCaptchaValidator class. I deleted the return $this->context. If i understand well, you don't need to return RequestContext object, and then your function return type declaration is now 'void'.