### PR TITLE
Deprecation Fix #14:  using spaceless plugin is deprecated with the newer vers…

### DIFF
--- a/src/Resources/views/form/recaptcha.html.twig
+++ b/src/Resources/views/form/recaptcha.html.twig
@@ -1,7 +1,7 @@
 {# @Recaptcha/form/recaptcha.html.twig #}
 
 {% block recaptcha_widget %}
-    {% apply spaceless %}
+    {#% apply spaceless %#}
         <div id="{{ id }}" data-toggle="recaptcha" data-type="{{ type }}">  
         </div>
         <script type="text/javascript">
@@ -61,5 +61,5 @@
     </script>
     <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?onload=onGoogleReCaptchaApiLoad&render=explicit&hl={{app.request.locale}}" async defer></script>
 
-    {% endapply %}
+    {#% endapply %#}
 {% endblock %}


### PR DESCRIPTION
Fixes #42 I've removed the `spaceless` filter in the view because since the last version of twig it seems that this filter is deprecated.